### PR TITLE
Fix issue with restricted html characters in window title

### DIFF
--- a/.config/waybar/scripts/window-name.sh
+++ b/.config/waybar/scripts/window-name.sh
@@ -5,5 +5,5 @@ class=$(hyprctl activewindow -j 2>/dev/null | jq -r '.class // empty')
 case "$class" in
 	kitty) echo Kitty ;;
 	google-chrome) echo Chrome ;;
-	*) hyprctl activewindow -j 2>/dev/null | jq -r '.title // empty' ;;
+	*) hyprctl activewindow -j 2>/dev/null | jq -r '.title|@html // empty' ;;
 esac

--- a/.config/waybar/scripts/window-name.sh
+++ b/.config/waybar/scripts/window-name.sh
@@ -5,5 +5,5 @@ class=$(hyprctl activewindow -j 2>/dev/null | jq -r '.class // empty')
 case "$class" in
 	kitty) echo Kitty ;;
 	google-chrome) echo Chrome ;;
-	*) hyprctl activewindow -j 2>/dev/null | jq -r '.title|@html // empty' ;;
+	*) hyprctl activewindow -j 2>/dev/null | jq -r '.title // empty |@html' ;;
 esac


### PR DESCRIPTION
HTML restricted characters cause errors in waybar. Use jq to do escaping of title strings to encode html restricted characters.